### PR TITLE
Add constants for the essential relation types.

### DIFF
--- a/src/main/java/edu/kit/datamanager/metastore2/runner/ElasticIndexerRunner.java
+++ b/src/main/java/edu/kit/datamanager/metastore2/runner/ElasticIndexerRunner.java
@@ -451,7 +451,7 @@ public class ElasticIndexerRunner implements CommandLineRunner {
 
     // Get resource type of schema....
     String format = null;
-    RelatedIdentifier identifier = DataResourceRecordUtil.getRelatedIdentifier(copy, RelatedIdentifier.RELATION_TYPES.IS_DERIVED_FROM);
+    RelatedIdentifier identifier = DataResourceRecordUtil.getRelatedIdentifier(copy, DataResourceRecordUtil.RELATED_NEW_VERSION_OF);
     if (identifier != null) {
       String schemaUrl = identifier.getValue();
       Optional<Url2Path> findByUrl = url2PathDao.findByUrl(schemaUrl);

--- a/src/main/java/edu/kit/datamanager/metastore2/runner/Migration2V2Runner.java
+++ b/src/main/java/edu/kit/datamanager/metastore2/runner/Migration2V2Runner.java
@@ -95,13 +95,13 @@ public class Migration2V2Runner {
     // Migrate relation type from 'isDerivedFrom' to 'hasMetadata'
     for (RelatedIdentifier item : recordByIdAndVersion.getRelatedIdentifiers()) {
       if (item.getRelationType().equals(RelatedIdentifier.RELATION_TYPES.IS_DERIVED_FROM)) {
-        item.setRelationType(RelatedIdentifier.RELATION_TYPES.HAS_METADATA);
+        item.setRelationType(DataResourceRecordUtil.RELATED_SCHEMA_TYPE);
       }
     }
     // Add provenance
     if (version > 1) {
       String schemaUrl = baseUrl + WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(SchemaRegistryControllerImplV2.class).getSchemaDocumentById(id, version - 1l, null, null)).toString();
-      RelatedIdentifier provenance = RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.IS_DERIVED_FROM, schemaUrl, null, null);
+      RelatedIdentifier provenance = RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_NEW_VERSION_OF, schemaUrl, null, null);
       recordByIdAndVersion.getRelatedIdentifiers().add(provenance);
       LOG.trace("Add provenance to datacite record: '{}'", schemaUrl);
     } else {
@@ -147,7 +147,7 @@ public class Migration2V2Runner {
     // Migrate relation type from 'isDerivedFrom' to 'hasMetadata'
     for (RelatedIdentifier item : recordByIdAndVersion.getRelatedIdentifiers()) {
       if (item.getRelationType().equals(RelatedIdentifier.RELATION_TYPES.IS_DERIVED_FROM)) {
-        item.setRelationType(RelatedIdentifier.RELATION_TYPES.HAS_METADATA);
+        item.setRelationType(DataResourceRecordUtil.RELATED_SCHEMA_TYPE);
         String replaceFirst = item.getValue().replaceFirst("/api/v1/schemas/", "/api/v2/schemas/");
         item.setValue(replaceFirst);
       }
@@ -155,7 +155,7 @@ public class Migration2V2Runner {
     // Add provenance
     if (version > 1) {
       String schemaUrl = baseUrl + WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(MetadataControllerImplV2.class).getMetadataDocumentById(id, version - 1l, null, null)).toString();
-      RelatedIdentifier provenance = RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.IS_DERIVED_FROM, schemaUrl, null, null);
+      RelatedIdentifier provenance = RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_NEW_VERSION_OF, schemaUrl, null, null);
       recordByIdAndVersion.getRelatedIdentifiers().add(provenance);
       LOG.trace("Add provenance to datacite record: '{}'", schemaUrl);
     } else {

--- a/src/main/java/edu/kit/datamanager/metastore2/util/MetadataRecordUtil.java
+++ b/src/main/java/edu/kit/datamanager/metastore2/util/MetadataRecordUtil.java
@@ -454,9 +454,9 @@ public class MetadataRecordUtil {
    * @param metadataRecord record holding resource information.
    */
   private static void updateRelatedIdentifierForResource(DataResource dataResource, MetadataRecord metadataRecord) {
-    RelatedIdentifier schemaRelatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+    RelatedIdentifier schemaRelatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
     if (schemaRelatedIdentifier == null) {
-      schemaRelatedIdentifier = RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, null, null, null);
+      schemaRelatedIdentifier = RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, null, null, null);
       dataResource.getRelatedIdentifiers().add(schemaRelatedIdentifier);
     }
     ResourceIdentifier schemaIdentifier = metadataRecord.getRelatedResource();
@@ -475,7 +475,7 @@ public class MetadataRecordUtil {
   private static void updateRelatedIdentifierForSchema(DataResource dataResource, MetadataRecord metadataRecord) {
     RelatedIdentifier schemaRelatedIdentifier = DataResourceRecordUtil.getSchemaIdentifier(dataResource);
     if (schemaRelatedIdentifier == null) {
-      schemaRelatedIdentifier = RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.HAS_METADATA, null, null, null);
+      schemaRelatedIdentifier = RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_SCHEMA_TYPE, null, null, null);
       dataResource.getRelatedIdentifiers().add(schemaRelatedIdentifier);
     }
     ResourceIdentifier schemaIdentifier = MetadataSchemaRecordUtil.getSchemaIdentifier(schemaConfig, metadataRecord);

--- a/src/test/java/edu/kit/datamanager/metastore2/test/CreateSchemaUtil.java
+++ b/src/test/java/edu/kit/datamanager/metastore2/test/CreateSchemaUtil.java
@@ -527,7 +527,7 @@ public class CreateSchemaUtil {
     if (versionAsString != null) {
       record.setVersion(versionAsString);
     }
-    RelatedIdentifier relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(record, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+    RelatedIdentifier relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(record, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
     relatedIdentifier.setValue("any");
     relatedIdentifier.setIdentifierType(Identifier.IDENTIFIER_TYPE.INTERNAL);
     record.getAcls().add(new AclEntry(AuthenticationHelper.ANONYMOUS_USER_PRINCIPAL, PERMISSION.READ));
@@ -560,7 +560,7 @@ public class CreateSchemaUtil {
         String etag = result.getResponse().getHeader("ETag");
         String body = result.getResponse().getContentAsString();
         record = mapper.readValue(body, DataResource.class);
-        relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(record, RelatedIdentifier.RELATION_TYPES.HAS_METADATA);
+        relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(record, DataResourceRecordUtil.RELATED_SCHEMA_TYPE);
         if ((schemaId != null) && schemaId.startsWith("http")) {
           relatedIdentifier.setIdentifierType(Identifier.IDENTIFIER_TYPE.URL);
         } else {

--- a/src/test/java/edu/kit/datamanager/metastore2/test/MetadataControllerFilterTestV2.java
+++ b/src/test/java/edu/kit/datamanager/metastore2/test/MetadataControllerFilterTestV2.java
@@ -382,7 +382,7 @@ public class MetadataControllerFilterTestV2 {
   @Test
   public void testFindRecordsByResourceId() throws Exception {
     for (int i = 1; i <= MAX_NO_OF_SCHEMAS; i++) {
-      edu.kit.datamanager.repo.domain.RelatedIdentifier relatedIdentifier = edu.kit.datamanager.repo.domain.RelatedIdentifier.factoryRelatedIdentifier(edu.kit.datamanager.repo.domain.RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, RELATED_RESOURCE + i, null, null);
+      edu.kit.datamanager.repo.domain.RelatedIdentifier relatedIdentifier = edu.kit.datamanager.repo.domain.RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, RELATED_RESOURCE + i, null, null);
       relatedIdentifier.setIdentifierType(Identifier.IDENTIFIER_TYPE.URL);
       MvcResult res = this.mockMvc.perform(get(API_METADATA_PATH)
               .param("resourceId", relatedIdentifier.getValue()))
@@ -394,9 +394,9 @@ public class MetadataControllerFilterTestV2 {
 
       Assert.assertEquals((MAX_NO_OF_SCHEMAS - i + 1) * 2, result.length);
       for (DataResource item : result) {
-        Assert.assertEquals(relatedIdentifier.getValue(), DataResourceRecordUtil.getRelatedIdentifier(item, edu.kit.datamanager.repo.domain.RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR).getValue());
-        Assert.assertEquals(relatedIdentifier.getIdentifierType(), DataResourceRecordUtil.getRelatedIdentifier(item, edu.kit.datamanager.repo.domain.RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR).getIdentifierType());
-        Assert.assertEquals(relatedIdentifier.getRelationType(), DataResourceRecordUtil.getRelatedIdentifier(item, edu.kit.datamanager.repo.domain.RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR).getRelationType());
+        Assert.assertEquals(relatedIdentifier.getValue(), DataResourceRecordUtil.getRelatedIdentifier(item, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE).getValue());
+        Assert.assertEquals(relatedIdentifier.getIdentifierType(), DataResourceRecordUtil.getRelatedIdentifier(item, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE).getIdentifierType());
+        Assert.assertEquals(relatedIdentifier.getRelationType(), DataResourceRecordUtil.getRelatedIdentifier(item, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE).getRelationType());
       }
     }
   }
@@ -467,7 +467,7 @@ public class MetadataControllerFilterTestV2 {
   @Test
   public void testFindRecordsByMultipleResourceIdsIncludingInvalidResourceId() throws Exception {
     for (int i = 1; i <= MAX_NO_OF_SCHEMAS; i++) {
-      edu.kit.datamanager.repo.domain.RelatedIdentifier relatedIdentifier = edu.kit.datamanager.repo.domain.RelatedIdentifier.factoryRelatedIdentifier(edu.kit.datamanager.repo.domain.RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, RELATED_RESOURCE + i, null, null);
+      edu.kit.datamanager.repo.domain.RelatedIdentifier relatedIdentifier = edu.kit.datamanager.repo.domain.RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, RELATED_RESOURCE + i, null, null);
       relatedIdentifier.setIdentifierType(Identifier.IDENTIFIER_TYPE.URL);
       MvcResult res = this.mockMvc.perform(get(API_METADATA_PATH)
               .param("resourceId", relatedIdentifier.getValue())
@@ -480,9 +480,9 @@ public class MetadataControllerFilterTestV2 {
 
       Assert.assertEquals((MAX_NO_OF_SCHEMAS - i + 1) * 2, result.length);
       for (DataResource item : result) {
-        Assert.assertEquals(relatedIdentifier.getValue(), DataResourceRecordUtil.getRelatedIdentifier(item, edu.kit.datamanager.repo.domain.RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR).getValue());
-        Assert.assertEquals(relatedIdentifier.getIdentifierType(), DataResourceRecordUtil.getRelatedIdentifier(item, edu.kit.datamanager.repo.domain.RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR).getIdentifierType());
-        Assert.assertEquals(relatedIdentifier.getRelationType(), DataResourceRecordUtil.getRelatedIdentifier(item, edu.kit.datamanager.repo.domain.RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR).getRelationType());
+        Assert.assertEquals(relatedIdentifier.getValue(), DataResourceRecordUtil.getRelatedIdentifier(item, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE).getValue());
+        Assert.assertEquals(relatedIdentifier.getIdentifierType(), DataResourceRecordUtil.getRelatedIdentifier(item, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE).getIdentifierType());
+        Assert.assertEquals(relatedIdentifier.getRelationType(), DataResourceRecordUtil.getRelatedIdentifier(item, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE).getRelationType());
       }
     }
   }
@@ -541,9 +541,9 @@ public class MetadataControllerFilterTestV2 {
    */
   public void ingestMetadataDocument(String schemaId, String resource) throws Exception {
     DataResource record = new DataResource();
-    edu.kit.datamanager.repo.domain.RelatedIdentifier schemaIdentifier = edu.kit.datamanager.repo.domain.RelatedIdentifier.factoryRelatedIdentifier(edu.kit.datamanager.repo.domain.RelatedIdentifier.RELATION_TYPES.HAS_METADATA, schemaId, null, null);
+    edu.kit.datamanager.repo.domain.RelatedIdentifier schemaIdentifier = edu.kit.datamanager.repo.domain.RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_SCHEMA_TYPE, schemaId, null, null);
     schemaIdentifier.setIdentifierType(Identifier.IDENTIFIER_TYPE.INTERNAL);
-    edu.kit.datamanager.repo.domain.RelatedIdentifier relatedIdentifier = edu.kit.datamanager.repo.domain.RelatedIdentifier.factoryRelatedIdentifier(edu.kit.datamanager.repo.domain.RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, resource, null, null);
+    edu.kit.datamanager.repo.domain.RelatedIdentifier relatedIdentifier = edu.kit.datamanager.repo.domain.RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, resource, null, null);
     relatedIdentifier.setIdentifierType(Identifier.IDENTIFIER_TYPE.URL);
     record.getRelatedIdentifiers().add(schemaIdentifier);
     record.getRelatedIdentifiers().add(relatedIdentifier);

--- a/src/test/java/edu/kit/datamanager/metastore2/test/MetadataControllerTestV2.java
+++ b/src/test/java/edu/kit/datamanager/metastore2/test/MetadataControllerTestV2.java
@@ -343,7 +343,7 @@ public class MetadataControllerTestV2 {
     String id = "testCreateRecordWithRelatedResourceOfTypeUrl";
     String schemaId = SCHEMA_ID;
     DataResource record = SchemaRegistryControllerTestV2.createDataResource4XmlDocument(id, schemaId);
-    RelatedIdentifier relatedResourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(record, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+    RelatedIdentifier relatedResourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(record, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
     relatedResourceIdentifier.setIdentifierType(Identifier.IDENTIFIER_TYPE.URL);
     ObjectMapper mapper = new ObjectMapper();
 
@@ -359,8 +359,8 @@ public class MetadataControllerTestV2 {
             andReturn();
 
     DataResource result = mapper.readValue(res.getResponse().getContentAsString(), DataResource.class);
-    RelatedIdentifier relatedIdentifier1 = DataResourceRecordUtil.getRelatedIdentifier(record, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
-    RelatedIdentifier relatedIdentifier2 = DataResourceRecordUtil.getRelatedIdentifier(result, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+    RelatedIdentifier relatedIdentifier1 = DataResourceRecordUtil.getRelatedIdentifier(record, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
+    RelatedIdentifier relatedIdentifier2 = DataResourceRecordUtil.getRelatedIdentifier(result, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
     Assert.assertEquals("Value of related resource should be unchanged!",
             relatedIdentifier1.getValue(),
             relatedIdentifier2.getValue());
@@ -390,7 +390,7 @@ public class MetadataControllerTestV2 {
     String schemaId = null;
     DataResource record = SchemaRegistryControllerTestV2.createDataResource4Document(id, schemaId);
     for (RelatedIdentifier item : record.getRelatedIdentifiers()) {
-      if (item.getRelationType().equals(RelatedIdentifier.RELATION_TYPES.HAS_METADATA)) {
+      if (item.getRelationType().equals(DataResourceRecordUtil.RELATED_SCHEMA_TYPE)) {
         item.setValue(null);
         item.setIdentifierType(Identifier.IDENTIFIER_TYPE.URL);
       }
@@ -415,7 +415,7 @@ public class MetadataControllerTestV2 {
     String schemaId = SCHEMA_ID;
     DataResource record = SchemaRegistryControllerTestV2.createDataResource4Document(id, schemaId);
     for (RelatedIdentifier item : record.getRelatedIdentifiers()) {
-      if (item.getRelationType().equals(RelatedIdentifier.RELATION_TYPES.HAS_METADATA)) {
+      if (item.getRelationType().equals(DataResourceRecordUtil.RELATED_SCHEMA_TYPE)) {
         item.setValue(invalidSchemaUrl);
         item.setIdentifierType(Identifier.IDENTIFIER_TYPE.URL);
       }
@@ -440,7 +440,7 @@ public class MetadataControllerTestV2 {
     String urlWithInvalidSchema = getSchemaUrl(SCHEMA_ID).replace(SCHEMA_ID, INVALID_SCHEMA);
     DataResource record = SchemaRegistryControllerTestV2.createDataResource4Document(id, schemaId);
     for (RelatedIdentifier item : record.getRelatedIdentifiers()) {
-      if (item.getRelationType().equals(RelatedIdentifier.RELATION_TYPES.HAS_METADATA)) {
+      if (item.getRelationType().equals(DataResourceRecordUtil.RELATED_SCHEMA_TYPE)) {
         item.setValue(urlWithInvalidSchema);
         item.setIdentifierType(Identifier.IDENTIFIER_TYPE.URL);
       }
@@ -475,7 +475,7 @@ public class MetadataControllerTestV2 {
     String schemaUrl = "http://anyurl.example.org/shouldNotExist";
     DataResource record = SchemaRegistryControllerTestV2.createDataResource4Document(id, schemaId);
     for (RelatedIdentifier item : record.getRelatedIdentifiers()) {
-      if (item.getRelationType().equals(RelatedIdentifier.RELATION_TYPES.HAS_METADATA)) {
+      if (item.getRelationType().equals(DataResourceRecordUtil.RELATED_SCHEMA_TYPE)) {
         item.setValue(schemaUrl);
         item.setIdentifierType(Identifier.IDENTIFIER_TYPE.URL);
       }
@@ -549,7 +549,7 @@ public class MetadataControllerTestV2 {
             file(recordFile).
             file(metadataFile)).andDo(print()).andExpect(status().isCreated()).andReturn();
     for (RelatedIdentifier item : record.getRelatedIdentifiers()) {
-      if (item.getRelationType().equals(RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR)) {
+      if (item.getRelationType().equals(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE)) {
         item.setValue(RELATED_RESOURCE_2.getIdentifier());
       }
     }
@@ -861,7 +861,7 @@ public class MetadataControllerTestV2 {
     String schemaId = SCHEMA_ID;
     DataResource record = SchemaRegistryControllerTestV2.createDataResource4Document(id, schemaId);
     //remove related resource
-    RelatedIdentifier relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(record, RelatedIdentifier.RELATION_TYPES.HAS_METADATA);
+    RelatedIdentifier relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(record, DataResourceRecordUtil.RELATED_SCHEMA_TYPE);
     record.getRelatedIdentifiers().remove(relatedIdentifier);
 
     MockMultipartFile recordFile = new MockMultipartFile("record", "metadata-record.json", "application/json", mapper.writeValueAsString(record).getBytes());
@@ -941,7 +941,7 @@ public class MetadataControllerTestV2 {
     DataResource result = mapper.readValue(res.getResponse().getContentAsString(), DataResource.class);
     Assert.assertEquals(1L, Long.parseLong(result.getVersion()));
 
-    DataResourceRecordUtil.getRelatedIdentifier(record, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR).setValue(RELATED_RESOURCE_2.toString());
+    DataResourceRecordUtil.getRelatedIdentifier(record, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE).setValue(RELATED_RESOURCE_2.toString());
     record.getAlternateIdentifiers().clear();
     record.setId(null);
     recordFile = new MockMultipartFile("record", "metadata-record.json", "application/json", mapper.writeValueAsString(record).getBytes());
@@ -1132,7 +1132,7 @@ public class MetadataControllerTestV2 {
       String schemaUrl = schemaIdentifier.getValue();
       Assert.assertTrue(schemaUrl.startsWith("http://localhost:"));
       Assert.assertTrue(schemaUrl.contains(API_SCHEMA_PATH));
-      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
       Assert.assertEquals(IDENTIFIER_TYPE.INTERNAL, resourceIdentifier.getIdentifierType());
       Assert.assertEquals(RELATED_RESOURCE.getIdentifier(), resourceIdentifier.getValue());
     }
@@ -1165,7 +1165,7 @@ public class MetadataControllerTestV2 {
       String schemaUrl = schemaIdentifier.getValue();
       Assert.assertTrue(schemaUrl.startsWith("http://localhost:"));
       Assert.assertTrue(schemaUrl.contains(API_SCHEMA_PATH));
-      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
       Assert.assertEquals(IDENTIFIER_TYPE.INTERNAL, resourceIdentifier.getIdentifierType());
       Assert.assertTrue(resourceIdentifier.getValue().endsWith("ResourceId"));
     }
@@ -1183,7 +1183,7 @@ public class MetadataControllerTestV2 {
       String schemaUrl = schemaIdentifier.getValue();
       Assert.assertTrue(schemaUrl.startsWith("http://localhost:"));
       Assert.assertTrue(schemaUrl.contains(API_SCHEMA_PATH));
-      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
       Assert.assertEquals(IDENTIFIER_TYPE.INTERNAL, resourceIdentifier.getIdentifierType());
       Assert.assertTrue(resourceIdentifier.getValue().endsWith("ResourceId"));
     }
@@ -1202,7 +1202,7 @@ public class MetadataControllerTestV2 {
       String schemaUrl = schemaIdentifier.getValue();
       Assert.assertTrue(schemaUrl.startsWith("http://localhost:"));
       Assert.assertTrue(schemaUrl.contains(API_SCHEMA_PATH));
-      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
       Assert.assertEquals(IDENTIFIER_TYPE.INTERNAL, resourceIdentifier.getIdentifierType());
       Assert.assertTrue(resourceIdentifier.getValue().endsWith("ResourceId"));
     }
@@ -1222,7 +1222,7 @@ public class MetadataControllerTestV2 {
       String schemaUrl = schemaIdentifier.getValue();
       Assert.assertTrue(schemaUrl.startsWith("http://localhost:"));
       Assert.assertTrue(schemaUrl.contains(API_SCHEMA_PATH));
-      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
       Assert.assertEquals(IDENTIFIER_TYPE.INTERNAL, resourceIdentifier.getIdentifierType());
       Assert.assertTrue(resourceIdentifier.getValue().endsWith("ResourceId"));
     }
@@ -1244,7 +1244,7 @@ public class MetadataControllerTestV2 {
       String schemaUrl = schemaIdentifier.getValue();
       Assert.assertTrue(schemaUrl.startsWith("http://localhost:"));
       Assert.assertTrue(schemaUrl.contains(API_SCHEMA_PATH));
-      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
       Assert.assertEquals(IDENTIFIER_TYPE.INTERNAL, resourceIdentifier.getIdentifierType());
       Assert.assertTrue(resourceIdentifier.getValue().endsWith("ResourceId"));
     }
@@ -1264,7 +1264,7 @@ public class MetadataControllerTestV2 {
       String schemaUrl = schemaIdentifier.getValue();
       Assert.assertTrue(schemaUrl.startsWith("http://localhost:"));
       Assert.assertTrue(schemaUrl.contains(API_SCHEMA_PATH));
-      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
       Assert.assertEquals(IDENTIFIER_TYPE.INTERNAL, resourceIdentifier.getIdentifierType());
       Assert.assertTrue(resourceIdentifier.getValue().endsWith("ResourceId"));
     }
@@ -1283,7 +1283,7 @@ public class MetadataControllerTestV2 {
       String schemaUrl = schemaIdentifier.getValue();
       Assert.assertTrue(schemaUrl.startsWith("http://localhost:"));
       Assert.assertTrue(schemaUrl.contains(API_SCHEMA_PATH));
-      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
       Assert.assertEquals(IDENTIFIER_TYPE.INTERNAL, resourceIdentifier.getIdentifierType());
       Assert.assertEquals(relatedResource, resourceIdentifier.getValue());
     }
@@ -1302,7 +1302,7 @@ public class MetadataControllerTestV2 {
       String schemaUrl = schemaIdentifier.getValue();
       Assert.assertTrue(schemaUrl.startsWith("http://localhost:"));
       Assert.assertTrue(schemaUrl.contains(API_SCHEMA_PATH));
-      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
       Assert.assertEquals(IDENTIFIER_TYPE.INTERNAL, resourceIdentifier.getIdentifierType());
       Assert.assertEquals(relatedResource2, resourceIdentifier.getValue());
     }
@@ -1322,7 +1322,7 @@ public class MetadataControllerTestV2 {
       String schemaUrl = schemaIdentifier.getValue();
       Assert.assertTrue(schemaUrl.startsWith("http://localhost:"));
       Assert.assertTrue(schemaUrl.contains(API_SCHEMA_PATH));
-      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
       Assert.assertEquals(IDENTIFIER_TYPE.INTERNAL, resourceIdentifier.getIdentifierType());
       Assert.assertTrue(resourceIdentifier.getValue().endsWith("ResourceId"));
     }
@@ -1341,7 +1341,7 @@ public class MetadataControllerTestV2 {
       String schemaUrl = schemaIdentifier.getValue();
       Assert.assertTrue(schemaUrl.startsWith("http://localhost:"));
       Assert.assertTrue(schemaUrl.contains(API_SCHEMA_PATH));
-      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
       Assert.assertEquals(IDENTIFIER_TYPE.INTERNAL, resourceIdentifier.getIdentifierType());
       Assert.assertEquals(relatedResource, resourceIdentifier.getValue());
     }
@@ -1360,7 +1360,7 @@ public class MetadataControllerTestV2 {
       String schemaUrl = schemaIdentifier.getValue();
       Assert.assertTrue(schemaUrl.startsWith("http://localhost:"));
       Assert.assertTrue(schemaUrl.contains(API_SCHEMA_PATH));
-      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+      RelatedIdentifier resourceIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
       Assert.assertEquals(IDENTIFIER_TYPE.INTERNAL, resourceIdentifier.getIdentifierType());
       Assert.assertEquals(relatedResource2, resourceIdentifier.getValue());
     }
@@ -1913,7 +1913,7 @@ public class MetadataControllerTestV2 {
 
     DataResource record = mapper.readValue(body, DataResource.class);
     DataResource record2 = mapper.readValue(body, DataResource.class);
-    RelatedIdentifier relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(record2, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+    RelatedIdentifier relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(record2, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
     expectedRelatedResource = relatedIdentifier.getValue() + "_NEW";
     relatedIdentifier.setValue(expectedRelatedResource);
     MockMultipartFile recordFile = new MockMultipartFile("record", "metadata-record.json", "application/json", mapper.writeValueAsString(record2).getBytes());
@@ -1931,14 +1931,14 @@ public class MetadataControllerTestV2 {
     Assert.assertEquals(record.getVersion(), record2.getVersion());// version should be the same
     SchemaRegistryControllerTestV2.validateSets(record.getAcls(), record2.getAcls());
     Assert.assertTrue(record.getLastUpdate().isBefore(record2.getLastUpdate()));
-    RelatedIdentifier relatedIdentifier1 = DataResourceRecordUtil.getRelatedIdentifier(record, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
-    RelatedIdentifier relatedIdentifier2 = DataResourceRecordUtil.getRelatedIdentifier(record2, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+    RelatedIdentifier relatedIdentifier1 = DataResourceRecordUtil.getRelatedIdentifier(record, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
+    RelatedIdentifier relatedIdentifier2 = DataResourceRecordUtil.getRelatedIdentifier(record2, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
     Assert.assertNotEquals("Related resource should be updated!", relatedIdentifier1.getValue(), relatedIdentifier2.getValue());
     Assert.assertEquals("Related resource should be updated!", expectedRelatedResource, relatedIdentifier2.getValue());
 
     // Test also updating related type only...
     IDENTIFIER_TYPE expectedIdentifierType = IDENTIFIER_TYPE.ISBN;
-    DataResourceRecordUtil.getRelatedIdentifier(record2, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR).setIdentifierType(expectedIdentifierType);
+    DataResourceRecordUtil.getRelatedIdentifier(record2, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE).setIdentifierType(expectedIdentifierType);
 
     recordFile = new MockMultipartFile("record", "metadata-record.json", "application/json", mapper.writeValueAsString(record2).getBytes());
 
@@ -1953,8 +1953,8 @@ public class MetadataControllerTestV2 {
     Assert.assertEquals(record2.getVersion(), record3.getVersion());// version should be the same
     SchemaRegistryControllerTestV2.validateSets(record2.getAcls(), record3.getAcls());
     Assert.assertTrue(record2.getLastUpdate().isBefore(record3.getLastUpdate()));
-    relatedIdentifier1 = DataResourceRecordUtil.getRelatedIdentifier(record2, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
-    relatedIdentifier2 = DataResourceRecordUtil.getRelatedIdentifier(record3, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+    relatedIdentifier1 = DataResourceRecordUtil.getRelatedIdentifier(record2, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
+    relatedIdentifier2 = DataResourceRecordUtil.getRelatedIdentifier(record3, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
     Assert.assertEquals("Related resource should be the same!", relatedIdentifier1.getValue(), relatedIdentifier2.getValue());
     Assert.assertEquals("Related resource type should be updated!", expectedIdentifierType, relatedIdentifier2.getIdentifierType());
 
@@ -2721,7 +2721,7 @@ public class MetadataControllerTestV2 {
   private String createDCMetadataRecordWithRelatedResource(String myRelatedResource, String schemaId) throws Exception {
     String randomId = UUID.randomUUID().toString();
     DataResource record = SchemaRegistryControllerTestV2.createDataResource4JsonDocument(randomId, schemaId);
-    RelatedIdentifier relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(record, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+    RelatedIdentifier relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(record, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
     relatedIdentifier.setIdentifierType(IDENTIFIER_TYPE.INTERNAL);
     relatedIdentifier.setValue(myRelatedResource);
     Set<AclEntry> aclEntries = new HashSet<>();
@@ -2792,7 +2792,7 @@ public class MetadataControllerTestV2 {
 
       ObjectMapper mapper = new ObjectMapper();
       DataResource record = mapper.readValue(body, DataResource.class);
-      RelatedIdentifier relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(record, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+      RelatedIdentifier relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(record, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
       relatedIdentifier.setValue(RELATED_RESOURCE_STRING + version);
       relatedIdentifier.setIdentifierType(IDENTIFIER_TYPE.INTERNAL);
 //      record.setRelatedResource(ResourceIdentifier.factoryInternalResourceIdentifier(RELATED_RESOURCE_STRING + version));

--- a/src/test/java/edu/kit/datamanager/metastore2/test/MetadataControllerTestWithAuthenticationEnabledV2.java
+++ b/src/test/java/edu/kit/datamanager/metastore2/test/MetadataControllerTestWithAuthenticationEnabledV2.java
@@ -495,7 +495,7 @@ public class MetadataControllerTestWithAuthenticationEnabledV2 {
             andDo(print()).
             andExpect(status().isCreated()).
             andReturn();
-    DataResourceRecordUtil.getRelatedIdentifier(record, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR).setValue(RELATED_RESOURCE_2.getIdentifier());
+    DataResourceRecordUtil.getRelatedIdentifier(record, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE).setValue(RELATED_RESOURCE_2.getIdentifier());
     recordFile = new MockMultipartFile("record", "metadata-record.json", "application/json", mapper.writeValueAsString(record).getBytes());
 
     this.mockMvc.perform(MockMvcRequestBuilders.multipart(API_METADATA_PATH).
@@ -887,7 +887,7 @@ public class MetadataControllerTestWithAuthenticationEnabledV2 {
         relatedIdentifiers.remove(item);
       }
     }
-    RelatedIdentifier relatedResource = RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, RELATED_RESOURCE_STRING_2, null, null);
+    RelatedIdentifier relatedResource = RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, RELATED_RESOURCE_STRING_2, null, null);
     relatedResource.setIdentifierType(Identifier.IDENTIFIER_TYPE.URL);
     relatedIdentifiers.add(relatedResource);
     record.getAlternateIdentifiers().clear();

--- a/src/test/java/edu/kit/datamanager/metastore2/test/SchemaRegistryControllerTestV2.java
+++ b/src/test/java/edu/kit/datamanager/metastore2/test/SchemaRegistryControllerTestV2.java
@@ -1984,10 +1984,10 @@ public class SchemaRegistryControllerTestV2 {
     setTitle(record, id);
     record.setResourceType(ResourceType.createResourceType(metadataType, ResourceType.TYPE_GENERAL.MODEL));
 
-    RelatedIdentifier relatedResource = RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, RELATED_RESOURCE_STRING, null, null);
+    RelatedIdentifier relatedResource = RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, RELATED_RESOURCE_STRING, null, null);
     relatedResource.setIdentifierType(Identifier.IDENTIFIER_TYPE.URL);
     record.getRelatedIdentifiers().add(relatedResource);
-    relatedResource = RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.HAS_METADATA, schemaId, null, null);
+    relatedResource = RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_SCHEMA_TYPE, schemaId, null, null);
     if ((schemaId != null) && schemaId.startsWith("http")) {
       relatedResource.setIdentifierType(Identifier.IDENTIFIER_TYPE.URL);
     } else {
@@ -2010,22 +2010,22 @@ public class SchemaRegistryControllerTestV2 {
   }
   
   public static void setRelatedResource(DataResource dataResource, String relatedResource) {
-    RelatedIdentifier relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR);
+    RelatedIdentifier relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE);
     if (relatedIdentifier != null) { 
       relatedIdentifier.setValue(relatedResource);
     } else {
-       relatedIdentifier = RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, relatedResource, null, null);
+       relatedIdentifier = RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, relatedResource, null, null);
     dataResource.getRelatedIdentifiers().add(relatedIdentifier);
     }
     relatedIdentifier.setIdentifierType(Identifier.IDENTIFIER_TYPE.URL);
  
   }
   public static void setRelatedSchema(DataResource dataResource, String relatedSchema) {
-    RelatedIdentifier relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, RelatedIdentifier.RELATION_TYPES.HAS_METADATA);
+    RelatedIdentifier relatedIdentifier = DataResourceRecordUtil.getRelatedIdentifier(dataResource, DataResourceRecordUtil.RELATED_SCHEMA_TYPE);
     if (relatedIdentifier != null) { 
       relatedIdentifier.setValue(relatedSchema);
     } else {
-       relatedIdentifier = RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.HAS_METADATA, relatedSchema, null, null);
+       relatedIdentifier = RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_SCHEMA_TYPE, relatedSchema, null, null);
     dataResource.getRelatedIdentifiers().add(relatedIdentifier);
     }
     if (relatedSchema.startsWith("http"))   {
@@ -2287,16 +2287,16 @@ public class SchemaRegistryControllerTestV2 {
     copyFirst.addAll(first);
     copySecond.addAll(second);
     for (RelatedIdentifier item : copyFirst) {
-      if (item.getRelationType() == RelatedIdentifier.RELATION_TYPES.IS_DERIVED_FROM) {
+      if (item.getRelationType() == DataResourceRecordUtil.RELATED_NEW_VERSION_OF) {
         provenanceFirstRelatedIdentifier = item;
-        Assert.assertEquals(RelatedIdentifier.RELATION_TYPES.IS_DERIVED_FROM, item.getRelationType());
+        Assert.assertEquals(DataResourceRecordUtil.RELATED_NEW_VERSION_OF, item.getRelationType());
         Assert.assertEquals(IDENTIFIER_TYPE.URL, item.getIdentifierType());
         break;
       }
     }
     for (RelatedIdentifier item : copySecond) {
-      if (item.getRelationType() == RelatedIdentifier.RELATION_TYPES.IS_DERIVED_FROM) {
-       Assert.assertEquals(RelatedIdentifier.RELATION_TYPES.IS_DERIVED_FROM, item.getRelationType());
+      if (item.getRelationType() == DataResourceRecordUtil.RELATED_NEW_VERSION_OF) {
+       Assert.assertEquals(DataResourceRecordUtil.RELATED_NEW_VERSION_OF, item.getRelationType());
       Assert.assertEquals(IDENTIFIER_TYPE.URL, item.getIdentifierType());
        provenanceSecondRelatedIdentifier = item;
        if (provenanceFirstRelatedIdentifier != null) {

--- a/src/test/java/edu/kit/datamanager/metastore2/util/DataResourceRecordUtilTest.java
+++ b/src/test/java/edu/kit/datamanager/metastore2/util/DataResourceRecordUtilTest.java
@@ -203,9 +203,9 @@ public class DataResourceRecordUtilTest {
   public void testFixSchemaUrl() throws URISyntaxException, IOException {
     System.out.println("testFixSchemaUrl");
     DataResourceRecordUtil.fixSchemaUrl((RelatedIdentifier) null);
-    RelatedIdentifier ri1 = RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, "test" + DataResourceRecordUtil.SCHEMA_VERSION_SEPARATOR + "1", null, null);
+    RelatedIdentifier ri1 = RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, "test" + DataResourceRecordUtil.SCHEMA_VERSION_SEPARATOR + "1", null, null);
     ri1.setIdentifierType(Identifier.IDENTIFIER_TYPE.INTERNAL);
-    RelatedIdentifier ri2 = RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, "test", null, null);
+    RelatedIdentifier ri2 = RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, "test", null, null);
     ri2.setIdentifierType(Identifier.IDENTIFIER_TYPE.INTERNAL);
     DataResourceRecordUtil.fixSchemaUrl(ri2);
     assertTrue("Found second version", ri2.getValue().endsWith("test2"));
@@ -217,7 +217,7 @@ public class DataResourceRecordUtilTest {
   public void testFixSchemaUrlWrongFormat() throws URISyntaxException, IOException {
     System.out.println("testFixSchemaUrl");
     DataResourceRecordUtil.fixSchemaUrl((RelatedIdentifier) null);
-    RelatedIdentifier ri1 = RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, "test" + DataResourceRecordUtil.SCHEMA_VERSION_SEPARATOR + "1" + DataResourceRecordUtil.SCHEMA_VERSION_SEPARATOR + "2", null, null);
+    RelatedIdentifier ri1 = RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, "test" + DataResourceRecordUtil.SCHEMA_VERSION_SEPARATOR + "1" + DataResourceRecordUtil.SCHEMA_VERSION_SEPARATOR + "2", null, null);
     ri1.setIdentifierType(Identifier.IDENTIFIER_TYPE.INTERNAL);
     DataResourceRecordUtil.fixSchemaUrl(ri1);
     // following line shouldn't be reached
@@ -231,16 +231,16 @@ public class DataResourceRecordUtilTest {
       DataResourceRecordUtil.validateRelatedResources4MetadataDocuments(null);
       assertTrue(false);
     } catch (BadArgumentException bae) {
-      assertTrue("Error should contain 'isMetadataFor'", bae.getMessage().contains("isMetadataFor"));
-      assertTrue("Error should contain 'hasMetadata'", bae.getMessage().contains("hasMetadata"));
+      assertTrue("Error should contain '" + DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE + "'", bae.getMessage().contains(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE.name()));
+      assertTrue("Error should contain '" + DataResourceRecordUtil.RELATED_SCHEMA_TYPE + "'", bae.getMessage().contains(DataResourceRecordUtil.RELATED_SCHEMA_TYPE.name()));
     }
     try {
       DataResource hasNoRelatedIdentifier = DataResource.factoryNewDataResource();
       DataResourceRecordUtil.validateRelatedResources4MetadataDocuments(hasNoRelatedIdentifier);
       assertTrue(false);
     } catch (BadArgumentException bae) {
-      assertTrue("Error should contain 'isMetadataFor'", bae.getMessage().contains("isMetadataFor"));
-      assertTrue("Error should contain 'hasMetadata'", bae.getMessage().contains("hasMetadata"));
+      assertTrue("Error should contain '" + DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE + "'", bae.getMessage().contains(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE.name()));
+      assertTrue("Error should contain '" + DataResourceRecordUtil.RELATED_SCHEMA_TYPE + "'", bae.getMessage().contains(DataResourceRecordUtil.RELATED_SCHEMA_TYPE.name()));
     }
     try {
       DataResource hasNeitherSchemaNorDataResource = DataResource.factoryNewDataResource();
@@ -249,61 +249,61 @@ public class DataResourceRecordUtilTest {
       DataResourceRecordUtil.validateRelatedResources4MetadataDocuments(hasNeitherSchemaNorDataResource);
       assertTrue(false);
     } catch (BadArgumentException bae) {
-      assertTrue("Error should contain 'isMetadataFor'", bae.getMessage().contains("isMetadataFor"));
-      assertTrue("Error should contain 'hasMetadata'", bae.getMessage().contains("hasMetadata"));
+      assertTrue("Error should contain '" + DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE + "'", bae.getMessage().contains(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE.name()));
+      assertTrue("Error should contain '" + DataResourceRecordUtil.RELATED_SCHEMA_TYPE + "'", bae.getMessage().contains(DataResourceRecordUtil.RELATED_SCHEMA_TYPE.name()));
     }
     try {
       DataResource hasTwoDataResourcesButNoSchema = DataResource.factoryNewDataResource();
-      hasTwoDataResourcesButNoSchema.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, "first data", null, null));
-      hasTwoDataResourcesButNoSchema.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, "second data", null, null));
+      hasTwoDataResourcesButNoSchema.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, "first data", null, null));
+      hasTwoDataResourcesButNoSchema.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, "second data", null, null));
       DataResourceRecordUtil.validateRelatedResources4MetadataDocuments(hasTwoDataResourcesButNoSchema);
       assertTrue(false);
     } catch (BadArgumentException bae) {
-      assertFalse("Multiple 'isMetadataFor' should be allowed!", bae.getMessage().contains("isMetadataFor"));
-      assertTrue("Error should contain 'hasMetadata'", bae.getMessage().contains("hasMetadata"));
+      assertFalse("Multiple '" + DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE + "' should be allowed!", bae.getMessage().contains(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE.name()));
+      assertTrue("Error should contain '" + DataResourceRecordUtil.RELATED_SCHEMA_TYPE + "'", bae.getMessage().contains(DataResourceRecordUtil.RELATED_SCHEMA_TYPE.name()));
     }
     try {
       DataResource hasTwoSchemasAndNoDataResource = DataResource.factoryNewDataResource();
-      hasTwoSchemasAndNoDataResource.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.HAS_METADATA, "first schema", null, null));
-      hasTwoSchemasAndNoDataResource.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.HAS_METADATA, "second schema", null, null));
+      hasTwoSchemasAndNoDataResource.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_SCHEMA_TYPE, "first schema", null, null));
+      hasTwoSchemasAndNoDataResource.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_SCHEMA_TYPE, "second schema", null, null));
       DataResourceRecordUtil.validateRelatedResources4MetadataDocuments(hasTwoSchemasAndNoDataResource);
       assertTrue(false);
     } catch (BadArgumentException bae) {
-      assertTrue("Error should contain 'hasMetadata'", bae.getMessage().contains("hasMetadata"));
-      assertTrue("Error should contain 'isMetadataFor'", bae.getMessage().contains("isMetadataFor"));
+      assertTrue("Error should contain '" + DataResourceRecordUtil.RELATED_SCHEMA_TYPE + "'", bae.getMessage().contains(DataResourceRecordUtil.RELATED_SCHEMA_TYPE.name()));
+      assertTrue("Error should contain '" + DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE + "'", bae.getMessage().contains(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE.name()));
     }
     try {
       DataResource hasOneSchemaAndNoDataResource = DataResource.factoryNewDataResource();
-      hasOneSchemaAndNoDataResource.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.HAS_METADATA, "first schema", null, null));
+      hasOneSchemaAndNoDataResource.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_SCHEMA_TYPE, "first schema", null, null));
       DataResourceRecordUtil.validateRelatedResources4MetadataDocuments(hasOneSchemaAndNoDataResource);
       assertTrue(false);
     } catch (BadArgumentException bae) {
-      assertFalse("Error should not contain 'hasMetadata'", bae.getMessage().contains("hasMetadata"));
-      assertTrue("Error should contain 'isMetadataFor'", bae.getMessage().contains("isMetadataFor"));
+      assertFalse("Error should not contain '" + DataResourceRecordUtil.RELATED_SCHEMA_TYPE + "'", bae.getMessage().contains(DataResourceRecordUtil.RELATED_SCHEMA_TYPE.name()));
+      assertTrue("Error should contain '" + DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE + "'", bae.getMessage().contains(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE.name()));
     }
     try {
       DataResource hasSchemaAndTwoDataResources = DataResource.factoryNewDataResource();
-      hasSchemaAndTwoDataResources.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.HAS_METADATA, "first schema", null, null));
-      hasSchemaAndTwoDataResources.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, "first data", null, null));
-      hasSchemaAndTwoDataResources.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, "second data", null, null));
+      hasSchemaAndTwoDataResources.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_SCHEMA_TYPE, "first schema", null, null));
+      hasSchemaAndTwoDataResources.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, "first data", null, null));
+      hasSchemaAndTwoDataResources.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, "second data", null, null));
       DataResourceRecordUtil.validateRelatedResources4MetadataDocuments(hasSchemaAndTwoDataResources);
       assertTrue(true);
     } catch (BadArgumentException bae) {
-      assertFalse("Error should not contain 'hasMetadata'", bae.getMessage().contains("hasMetadata"));
-      assertFalse("Multiple 'isMetadataFor' should be allowed!", bae.getMessage().contains("isMetadataFor"));
+      assertFalse("Error should not contain '" + DataResourceRecordUtil.RELATED_SCHEMA_TYPE + "'", bae.getMessage().contains(DataResourceRecordUtil.RELATED_SCHEMA_TYPE.name()));
+      assertFalse("Multiple '" + DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE + "' should be allowed!", bae.getMessage().contains(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE.name()));
       assertTrue(false);
     }
     try {
       DataResource hasTwoSchemasAndTwoDataResources = DataResource.factoryNewDataResource();
-      hasTwoSchemasAndTwoDataResources.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.HAS_METADATA, "first schema", null, null));
-      hasTwoSchemasAndTwoDataResources.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.HAS_METADATA, "second schema", null, null));
-      hasTwoSchemasAndTwoDataResources.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, "first data", null, null));
-      hasTwoSchemasAndTwoDataResources.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.IS_METADATA_FOR, "second data", null, null));
+      hasTwoSchemasAndTwoDataResources.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_SCHEMA_TYPE, "first schema", null, null));
+      hasTwoSchemasAndTwoDataResources.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_SCHEMA_TYPE, "second schema", null, null));
+      hasTwoSchemasAndTwoDataResources.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, "first data", null, null));
+      hasTwoSchemasAndTwoDataResources.getRelatedIdentifiers().add(RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE, "second data", null, null));
       DataResourceRecordUtil.validateRelatedResources4MetadataDocuments(hasTwoSchemasAndTwoDataResources);
       assertTrue(false);
     } catch (BadArgumentException bae) {
-      assertTrue("Error should contain 'hasMetadata'", bae.getMessage().contains("hasMetadata"));
-      assertFalse("Multiple 'isMetadataFor' should be allowed!", bae.getMessage().contains("isMetadataFor"));
+      assertTrue("Error should contain '" + DataResourceRecordUtil.RELATED_SCHEMA_TYPE + "'", bae.getMessage().contains(DataResourceRecordUtil.RELATED_SCHEMA_TYPE.name()));
+      assertFalse("Multiple '" + DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE + "' should be allowed!", bae.getMessage().contains(DataResourceRecordUtil.RELATED_DATA_RESOURCE_TYPE.name()));
     }
   }
 

--- a/src/test/java/edu/kit/datamanager/metastore2/util/MetadataRecordUtilTest.java
+++ b/src/test/java/edu/kit/datamanager/metastore2/util/MetadataRecordUtilTest.java
@@ -729,7 +729,7 @@ public class MetadataRecordUtilTest {
     //@ToDo Make this working again
 //    dataResource.getTitles().add(Title.factoryTitle(SCHEMA_ID));
 //    dataResource.setResourceType(ResourceType.createResourceType(SCHEMA_ID));
-//    RelatedIdentifier relId = RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.HAS_METADATA, SCHEMA_ID, null, null);
+//    RelatedIdentifier relId = RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_SCHEMA_TYPE, SCHEMA_ID, null, null);
 //    relId.setIdentifierType(Identifier.IDENTIFIER_TYPE.INTERNAL);
 //    dataResource.getRelatedIdentifiers().add(relId);
 //    // dataResourceService adds ACL
@@ -819,7 +819,7 @@ public class MetadataRecordUtilTest {
   }
 
   private void setSchema(DataResource dataResource) {
-    RelatedIdentifier factoryRelatedIdentifier = RelatedIdentifier.factoryRelatedIdentifier(RelatedIdentifier.RELATION_TYPES.HAS_METADATA, "anySchema", null, null);
+    RelatedIdentifier factoryRelatedIdentifier = RelatedIdentifier.factoryRelatedIdentifier(DataResourceRecordUtil.RELATED_SCHEMA_TYPE, "anySchema", null, null);
     factoryRelatedIdentifier.setIdentifierType(Identifier.IDENTIFIER_TYPE.INTERNAL);
     dataResource.getRelatedIdentifiers().add(factoryRelatedIdentifier);
   }


### PR DESCRIPTION
Switch relation type for identifier pointing to the previous version from 'IS_DERIVED_FROM' to 'IS_NEW_VERSION_OF'.